### PR TITLE
feat(admin,user): implement location assignment

### DIFF
--- a/backend/src/database/migrations/1751810939581-assign-location.ts
+++ b/backend/src/database/migrations/1751810939581-assign-location.ts
@@ -1,0 +1,98 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  TableColumn,
+  TableForeignKey,
+} from 'typeorm';
+
+export class AssignLocation1751810939581 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn(
+      'users',
+      new TableColumn({
+        name: 'assigned_state_id',
+        type: 'uuid',
+        isNullable: true,
+      }),
+    );
+    await queryRunner.createForeignKey(
+      'users',
+      new TableForeignKey({
+        columnNames: ['assigned_state_id'],
+        referencedTableName: 'states',
+        referencedColumnNames: ['id'],
+        onDelete: 'SET NULL',
+        name: 'FK_users_assigned_state',
+      }),
+    );
+
+    await queryRunner.addColumn(
+      'users',
+      new TableColumn({
+        name: 'assigned_local_government_id',
+        type: 'uuid',
+        isNullable: true,
+      }),
+    );
+    await queryRunner.createForeignKey(
+      'users',
+      new TableForeignKey({
+        columnNames: ['assigned_local_government_id'],
+        referencedTableName: 'local_governments',
+        referencedColumnNames: ['id'],
+        onDelete: 'SET NULL',
+        name: 'FK_users_assigned_lga',
+      }),
+    );
+
+    await queryRunner.addColumn(
+      'users',
+      new TableColumn({
+        name: 'assigned_phase_id',
+        type: 'uuid',
+        isNullable: true,
+      }),
+    );
+    await queryRunner.createForeignKey(
+      'users',
+      new TableForeignKey({
+        columnNames: ['assigned_phase_id'],
+        referencedTableName: 'phases',
+        referencedColumnNames: ['id'],
+        onDelete: 'SET NULL',
+        name: 'FK_users_assigned_phase',
+      }),
+    );
+
+    await queryRunner.addColumn(
+      'users',
+      new TableColumn({
+        name: 'assigned_district_id',
+        type: 'uuid',
+        isNullable: true,
+      }),
+    );
+    await queryRunner.createForeignKey(
+      'users',
+      new TableForeignKey({
+        columnNames: ['assigned_district_id'],
+        referencedTableName: 'districts',
+        referencedColumnNames: ['id'],
+        onDelete: 'SET NULL',
+        name: 'FK_users_assigned_district',
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropForeignKey('users', 'FK_users_assigned_district');
+    await queryRunner.dropForeignKey('users', 'FK_users_assigned_phase');
+    await queryRunner.dropForeignKey('users', 'FK_users_assigned_lga');
+    await queryRunner.dropForeignKey('users', 'FK_users_assigned_state');
+
+    await queryRunner.dropColumn('users', 'assigned_district_id');
+    await queryRunner.dropColumn('users', 'assigned_phase_id');
+    await queryRunner.dropColumn('users', 'assigned_local_government_id');
+    await queryRunner.dropColumn('users', 'assigned_state_id');
+  }
+}

--- a/backend/src/modules/admin/admin.controller.spec.ts
+++ b/backend/src/modules/admin/admin.controller.spec.ts
@@ -21,6 +21,7 @@ const mockUserService = {
   deactivateUser: jest.fn().mockResolvedValue(undefined),
   reactivateUser: jest.fn().mockResolvedValue(undefined),
   listUsers: jest.fn().mockResolvedValue({ data: [], total: 0 }),
+  assignLocationToUser: jest.fn().mockResolvedValue(undefined),
 };
 
 const mockAdminService = {
@@ -73,9 +74,52 @@ describe('AdminController', () => {
     expect(controller).toBeDefined();
   });
 
+  describe('assignLocation', () => {
+    it('should call userService.assignLocationToUser with correct arguments and return the expected result', async () => {
+      const userId = 'user-123';
+      const assignLocationDto = {
+        stateId: 'state-1',
+        localGovernmentId: 'lg-1',
+        phaseId: 'phase-1',
+        districtId: 'district-1',
+      };
+      const expectedResult = {
+        message: 'Location Assignment operation successful',
+        data: { userId: 'user-123', ...assignLocationDto },
+      };
+      mockUserService.assignLocationToUser.mockResolvedValueOnce(
+        expectedResult,
+      );
+
+      const result = await controller.assignLocation(userId, assignLocationDto);
+
+      expect(mockUserService.assignLocationToUser).toHaveBeenCalledWith(
+        userId,
+        assignLocationDto,
+      );
+      expect(result).toEqual(expectedResult);
+    });
+
+    it('should handle errors from userService.assignLocationToUser', async () => {
+      const userId = 'user-123';
+      const assignLocationDto = {
+        stateId: 'state-1',
+        localGovernmentId: 'lg-1',
+        phaseId: 'phase-1',
+        districtId: 'district-1',
+      };
+      const error = new Error('Location assignment failed');
+      mockUserService.assignLocationToUser.mockRejectedValueOnce(error);
+
+      await expect(
+        controller.assignLocation(userId, assignLocationDto),
+      ).rejects.toThrow(error);
+    });
+  });
+
   describe('deactivateUser', () => {
     it('should call userService.deactivateUser with correct id and return the expected result', async () => {
-      const body = { userId: 'user-123' };
+      const userId = 'user-123';
       const req = { user: { sub: 'admin-123' } } as Request & {
         user: { sub: string };
       };
@@ -85,7 +129,7 @@ describe('AdminController', () => {
       };
       mockUserService.deactivateUser.mockResolvedValueOnce(expectedResult);
 
-      const result = await controller.deactivateUser(body, req);
+      const result = await controller.deactivateUser(userId, req);
 
       expect(mockUserService.deactivateUser).toHaveBeenCalledWith(
         'user-123',
@@ -95,20 +139,22 @@ describe('AdminController', () => {
     });
 
     it('should handle errors from userService.deactivateUser', async () => {
-      const body = { userId: 'user-123' };
+      const userId = 'user-123';
       const req = { user: { sub: 'admin-123' } } as Request & {
         user: { sub: string };
       };
       const error = new Error('Deactivation failed');
       mockUserService.deactivateUser.mockRejectedValueOnce(error);
 
-      await expect(controller.deactivateUser(body, req)).rejects.toThrow(error);
+      await expect(controller.deactivateUser(userId, req)).rejects.toThrow(
+        error,
+      );
     });
   });
 
   describe('reactivateUser', () => {
     it('should call userService.reactivateUser with correct id and return the expected result', async () => {
-      const body = { userId: 'user-123' };
+      const userId = 'user-123';
       const req = { user: { sub: 'admin-123' } } as Request & {
         user: { sub: string };
       };
@@ -118,7 +164,7 @@ describe('AdminController', () => {
       };
       mockUserService.reactivateUser.mockResolvedValueOnce(expectedResult);
 
-      const result = await controller.reactivateUser(body, req);
+      const result = await controller.reactivateUser(userId, req);
 
       expect(mockUserService.reactivateUser).toHaveBeenCalledWith(
         'user-123',
@@ -128,14 +174,16 @@ describe('AdminController', () => {
     });
 
     it('should handle errors from userService.reactivateUser', async () => {
-      const body = { userId: 'user-123' };
+      const userId = 'user-123';
       const req = { user: { sub: 'admin-123' } } as Request & {
         user: { sub: string };
       };
       const error = new Error('Reactivation failed');
       mockUserService.reactivateUser.mockRejectedValueOnce(error);
 
-      await expect(controller.reactivateUser(body, req)).rejects.toThrow(error);
+      await expect(controller.reactivateUser(userId, req)).rejects.toThrow(
+        error,
+      );
     });
   });
 

--- a/backend/src/modules/admin/admin.controller.ts
+++ b/backend/src/modules/admin/admin.controller.ts
@@ -18,8 +18,8 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { AdminService } from './admin.service';
-import { UserQueryValidator } from '../user/dto/user.dto';
 import { StoreQueryValidator } from '../store/dto/store.dto';
+import { AssignLocationDto, UserQueryValidator } from '../user/dto/user.dto';
 
 @Controller('admin')
 @UseGuards(RoleGuard)
@@ -31,21 +31,30 @@ export class AdminController {
   ) {}
 
   @HttpCode(HttpStatus.OK)
-  @Post('users/deactivate')
-  async deactivateUser(
-    @Body() body: { userId: string },
-    @Req() req: Request & { user: { sub: string } },
+  @Post('users/:userId/assign-location')
+  async assignLocation(
+    @Param('userId') userId: string,
+    @Body() assignLocationDto: AssignLocationDto,
   ) {
-    return this.userService.deactivateUser(body.userId, req.user.sub);
+    return this.userService.assignLocationToUser(userId, assignLocationDto);
   }
 
   @HttpCode(HttpStatus.OK)
-  @Post('users/reactivate')
-  async reactivateUser(
-    @Body() body: { userId: string },
+  @Post('users/:userId/deactivate')
+  async deactivateUser(
+    @Param('userId') userId: string,
     @Req() req: Request & { user: { sub: string } },
   ) {
-    return this.userService.reactivateUser(body.userId, req.user.sub);
+    return this.userService.deactivateUser(userId, req.user.sub);
+  }
+
+  @HttpCode(HttpStatus.OK)
+  @Post('users/:userId/reactivate')
+  async reactivateUser(
+    @Param('userId') userId: string,
+    @Req() req: Request & { user: { sub: string } },
+  ) {
+    return this.userService.reactivateUser(userId, req.user.sub);
   }
 
   @Get('users')

--- a/backend/src/modules/district/entities/district.entity.ts
+++ b/backend/src/modules/district/entities/district.entity.ts
@@ -6,6 +6,7 @@ import {
   JoinColumn,
   Index,
 } from 'typeorm';
+import { User } from '~/modules/user/entities/user.entity';
 import { Phase } from '~/modules/phase/entities/phase.entity';
 import { Store } from '~/modules/store/entities/store.entity';
 import { AbstractBaseEntity } from '~/database/base/base.entity';
@@ -25,4 +26,7 @@ export class District extends AbstractBaseEntity {
 
   @OneToMany(() => Store, (store) => store.district)
   stores: Store[];
+
+  @OneToMany(() => User, (user) => user.assignedDistrict, { nullable: true })
+  users?: User[];
 }

--- a/backend/src/modules/local-government/entities/local-government.entity.ts
+++ b/backend/src/modules/local-government/entities/local-government.entity.ts
@@ -1,14 +1,15 @@
+import {
+  Index,
+  Entity,
+  Column,
+  OneToMany,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { User } from '~/modules/user/entities/user.entity';
 import { Store } from '~/modules/store/entities/store.entity';
 import { State } from '~/modules/state/entities/state.entity';
 import { AbstractBaseEntity } from '~/database/base/base.entity';
-import {
-  Entity,
-  OneToMany,
-  Column,
-  ManyToOne,
-  JoinColumn,
-  Index,
-} from 'typeorm';
 
 @Entity({ name: 'local_governments' })
 export class LocalGovernment extends AbstractBaseEntity {
@@ -23,4 +24,9 @@ export class LocalGovernment extends AbstractBaseEntity {
   stateId: string;
   @OneToMany(() => Store, (store) => store.localGovernment)
   stores: Store[];
+
+  @OneToMany(() => User, (user) => user.assignedLocalGovernment, {
+    nullable: true,
+  })
+  users?: User[];
 }

--- a/backend/src/modules/phase/entities/phase.entity.ts
+++ b/backend/src/modules/phase/entities/phase.entity.ts
@@ -6,10 +6,11 @@ import {
   JoinColumn,
   Index,
 } from 'typeorm';
+import { User } from '~/modules/user/entities/user.entity';
 import { Store } from '~/modules/store/entities/store.entity';
+import { State } from '~/modules/state/entities/state.entity';
 import { AbstractBaseEntity } from '~/database/base/base.entity';
 import { District } from '~/modules/district/entities/district.entity';
-import { State } from '~/modules/state/entities/state.entity';
 
 @Entity({ name: 'phases' })
 export class Phase extends AbstractBaseEntity {
@@ -29,4 +30,7 @@ export class Phase extends AbstractBaseEntity {
 
   @OneToMany(() => District, (district) => district.phase)
   districts: District[];
+
+  @OneToMany(() => User, (user) => user.assignedPhase, { nullable: true })
+  users?: User[];
 }

--- a/backend/src/modules/phase/types/phase.interface.ts
+++ b/backend/src/modules/phase/types/phase.interface.ts
@@ -1,5 +1,7 @@
 import { AbstractBaseInterface } from '~/database/base/base.interface';
+import { DistrictInterface } from '~/modules/district/types/district.interface';
 
 export interface PhaseInterface extends AbstractBaseInterface {
   name: string;
+  districts?: DistrictInterface[];
 }

--- a/backend/src/modules/state/entities/state.entity.ts
+++ b/backend/src/modules/state/entities/state.entity.ts
@@ -1,4 +1,5 @@
 import { Entity, OneToMany, Column } from 'typeorm';
+import { User } from '~/modules/user/entities/user.entity';
 import { Store } from '~/modules/store/entities/store.entity';
 import { Phase } from '~/modules/phase/entities/phase.entity';
 import { AbstractBaseEntity } from '~/database/base/base.entity';
@@ -17,4 +18,7 @@ export class State extends AbstractBaseEntity {
 
   @OneToMany(() => Phase, (phase) => phase.state, { nullable: true })
   phases?: Phase[];
+
+  @OneToMany(() => User, (user) => user.assignedState, { nullable: true })
+  users?: User[];
 }

--- a/backend/src/modules/state/types/state.interface.ts
+++ b/backend/src/modules/state/types/state.interface.ts
@@ -1,5 +1,9 @@
 import { AbstractBaseInterface } from '~/database/base/base.interface';
+import { LocalGovernmentInterface } from '~/modules/local-government/types/local-government.interface';
+import { PhaseInterface } from '~/modules/phase/types/phase.interface';
 
 export interface StateInterface extends AbstractBaseInterface {
   name: string;
+  localGovernments?: LocalGovernmentInterface[];
+  phases?: PhaseInterface[];
 }

--- a/backend/src/modules/user/dto/user.dto.ts
+++ b/backend/src/modules/user/dto/user.dto.ts
@@ -42,3 +42,21 @@ export class UserQueryValidator extends QueryValidator {
   @IsEnum(AuthProvider)
   authProvider?: AuthProvider;
 }
+
+export class AssignLocationDto {
+  @IsString()
+  @IsNotEmpty()
+  stateId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  localGovernmentId: string;
+
+  @IsString()
+  @IsOptional()
+  phaseId?: string;
+
+  @IsString()
+  @IsOptional()
+  districtId?: string;
+}

--- a/backend/src/modules/user/entities/user.entity.ts
+++ b/backend/src/modules/user/entities/user.entity.ts
@@ -39,6 +39,18 @@ export class User extends AbstractBaseEntity {
   @Column({ nullable: true })
   resetPasswordExpires?: Date;
 
+  @Column({ nullable: true })
+  assignedStateId?: string;
+
+  @Column({ nullable: true })
+  assignedLocalGovernmentId?: string;
+
+  @Column({ nullable: true })
+  assignedPhaseId?: string;
+
+  @Column({ nullable: true })
+  assignedDistrictId?: string;
+
   @OneToMany(() => Store, (store) => store.enumerator)
   stores: Store[];
 }

--- a/backend/src/modules/user/entities/user.entity.ts
+++ b/backend/src/modules/user/entities/user.entity.ts
@@ -1,8 +1,12 @@
-import { Entity, Column, OneToMany } from 'typeorm';
 import { Store } from '~/modules/store/entities/store.entity';
+import { State } from '~/modules/state/entities/state.entity';
+import { Phase } from '~/modules/phase/entities/phase.entity';
 import { AbstractBaseEntity } from '~/database/base/base.entity';
 import { AuthProvider } from '~/modules/auth/constants/auth.constant';
+import { District } from '~/modules/district/entities/district.entity';
+import { Entity, Column, OneToMany, ManyToOne, JoinColumn } from 'typeorm';
 import { UserRole, UserStatus } from '~/modules/user/constants/user.constant';
+import { LocalGovernment } from '~/modules/local-government/entities/local-government.entity';
 
 @Entity({ name: 'users' })
 export class User extends AbstractBaseEntity {
@@ -42,14 +46,34 @@ export class User extends AbstractBaseEntity {
   @Column({ nullable: true })
   assignedStateId?: string;
 
+  @JoinColumn({ name: 'assigned_state_id' })
+  @ManyToOne(() => State, (state) => state.users, { nullable: true })
+  assignedState?: State;
+
   @Column({ nullable: true })
   assignedLocalGovernmentId?: string;
+
+  @JoinColumn({ name: 'assigned_local_government_id' })
+  @ManyToOne(
+    () => LocalGovernment,
+    (localGovernment) => localGovernment.users,
+    { nullable: true },
+  )
+  assignedLocalGovernment?: LocalGovernment;
 
   @Column({ nullable: true })
   assignedPhaseId?: string;
 
+  @JoinColumn({ name: 'assigned_phase_id' })
+  @ManyToOne(() => Phase, (phase) => phase.users, { nullable: true })
+  assignedPhase?: Phase;
+
   @Column({ nullable: true })
   assignedDistrictId?: string;
+
+  @JoinColumn({ name: 'assigned_district_id' })
+  @ManyToOne(() => District, (district) => district.users, { nullable: true })
+  assignedDistrict?: District;
 
   @OneToMany(() => Store, (store) => store.enumerator)
   stores: Store[];

--- a/backend/src/modules/user/types/user.interface.ts
+++ b/backend/src/modules/user/types/user.interface.ts
@@ -10,4 +10,8 @@ export interface UserInterface extends AbstractBaseInterface {
   authProvider: AuthProvider;
   resetPasswordToken?: string;
   resetPasswordExpires?: Date;
+  assignedStateId?: string;
+  assignedLocalGovernmentId?: string;
+  assignedPhaseId?: string;
+  assignedDistrictId?: string;
 }

--- a/backend/src/modules/user/user.module.ts
+++ b/backend/src/modules/user/user.module.ts
@@ -2,10 +2,11 @@ import { Module } from '@nestjs/common';
 import { UserService } from './user.service';
 import { User } from './entities/user.entity';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { StateModule } from '../state/state.module';
 import { UserModelAction } from './user.model-action';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User])],
+  imports: [TypeOrmModule.forFeature([User]), StateModule],
   providers: [UserService, UserModelAction],
   exports: [UserService, UserModelAction],
 })

--- a/backend/src/modules/user/user.service.spec.ts
+++ b/backend/src/modules/user/user.service.spec.ts
@@ -6,6 +6,7 @@ import {
   ListUserRecordOptions,
   UserQueryOptions,
 } from './types/list-user.type';
+import { StateService } from '../state/state.service';
 
 interface MockUserModelAction {
   list: jest.Mock<
@@ -31,6 +32,12 @@ describe('UserService', () => {
         {
           provide: UserModelAction,
           useValue: mockModelAction,
+        },
+        {
+          provide: StateService,
+          useValue: {
+            getStateById: jest.fn(),
+          },
         },
       ],
     }).compile();

--- a/backend/src/modules/user/user.service.ts
+++ b/backend/src/modules/user/user.service.ts
@@ -1,5 +1,8 @@
+import { AssignLocationDto } from './dto/user.dto';
 import * as SYS_MSG from '~/helpers/system-messages';
+import { StateService } from '../state/state.service';
 import { UserModelAction } from './user.model-action';
+import { EntityPropertyNotFoundError } from 'typeorm';
 import { HttpStatus, Injectable } from '@nestjs/common';
 import UpdateUserRecordOptions from './types/update-user.type';
 import CreateUserRecordOptions from './types/create-user.type';
@@ -7,14 +10,120 @@ import { NullishValueError, trySafe } from '~/helpers/try-safe';
 import { CustomHttpException } from '~/helpers/custom.exception';
 import { UserRole, UserStatus } from './constants/user.constant';
 import {
-  ListUserRecordOptions,
   UserQueryOptions,
+  ListUserRecordOptions,
 } from './types/list-user.type';
-import { EntityPropertyNotFoundError } from 'typeorm';
 
 @Injectable()
 export class UserService {
-  constructor(private userModelAction: UserModelAction) {}
+  constructor(
+    private stateService: StateService,
+    private userModelAction: UserModelAction,
+  ) {}
+
+  async assignLocationToUser(
+    userId: string,
+    assignLocationDto: AssignLocationDto,
+  ) {
+    const { stateId, localGovernmentId, phaseId, districtId } =
+      assignLocationDto;
+
+    const [userError, user] = await trySafe(() => this.getUserById(userId));
+
+    if (userError || !user) {
+      throw new CustomHttpException(
+        SYS_MSG.RESOURCE_NOT_FOUND('User'),
+        HttpStatus.NOT_FOUND,
+      );
+    }
+
+    const [stateError, stateData] = await trySafe(() =>
+      this.stateService.getStateById(
+        stateId,
+        {},
+        {
+          localGovernments: true,
+          phases: {
+            districts: true,
+          },
+        },
+      ),
+    );
+
+    if (stateError || !stateData) {
+      throw new CustomHttpException(
+        SYS_MSG.RESOURCE_NOT_FOUND('State'),
+        HttpStatus.NOT_FOUND,
+      );
+    }
+
+    const state = stateData.data;
+
+    const localGovernment = state?.localGovernments?.find(
+      (lg) => lg.id === localGovernmentId,
+    );
+
+    if (!localGovernment) {
+      throw new CustomHttpException(
+        'Local government does not belong to the selected state',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    if (phaseId) {
+      if (!districtId) {
+        throw new CustomHttpException(
+          'District is required when a phase is selected',
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+
+      const phase = state?.phases?.find((p) => p.id === phaseId);
+
+      if (!phase) {
+        throw new CustomHttpException(
+          'Phase does not belong to the selected state',
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+
+      const district = phase?.districts?.find((d) => d.id === districtId);
+
+      if (!district) {
+        throw new CustomHttpException(
+          'District does not belong to the selected phase',
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+    }
+
+    const payload: UpdateUserRecordOptions = {
+      identifierOptions: { id: userId },
+      updatePayload: {
+        assignedStateId: stateId,
+        assignedLocalGovernmentId: localGovernmentId,
+        assignedPhaseId: phaseId,
+        assignedDistrictId: districtId,
+      },
+      transactionOptions: {
+        useTransaction: false,
+      },
+    };
+
+    const [updateError, data] = await trySafe(() => this.updateUser(payload));
+
+    if (updateError) {
+      throw new CustomHttpException(
+        SYS_MSG.RESOURCE_OPERATION_FAILED('Location Assignment'),
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+
+    return {
+      message: SYS_MSG.RESOURCE_OPERATION_SUCCESSFUL('Location Assignment'),
+      data,
+    };
+  }
 
   async createUser(createUserPayload: CreateUserRecordOptions) {
     const [error, data] = await trySafe(() =>

--- a/backend/src/modules/user/user.service.ts
+++ b/backend/src/modules/user/user.service.ts
@@ -59,13 +59,22 @@ export class UserService {
 
     const state = stateData.data;
 
-    const localGovernment = state?.localGovernments?.find(
-      (lg) => lg.id === localGovernmentId,
-    );
+    if (localGovernmentId) {
+      const localGovernment = state?.localGovernments?.find(
+        (lg) => lg.id === localGovernmentId,
+      );
 
-    if (!localGovernment) {
+      if (!localGovernment) {
+        throw new CustomHttpException(
+          'Local government does not belong to the selected state',
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+    }
+
+    if (districtId && !phaseId) {
       throw new CustomHttpException(
-        'Local government does not belong to the selected state',
+        'Phase is required when a district is selected',
         HttpStatus.BAD_REQUEST,
       );
     }
@@ -100,10 +109,12 @@ export class UserService {
     const payload: UpdateUserRecordOptions = {
       identifierOptions: { id: userId },
       updatePayload: {
-        assignedStateId: stateId,
-        assignedLocalGovernmentId: localGovernmentId,
-        assignedPhaseId: phaseId,
-        assignedDistrictId: districtId,
+        ...(stateId && { assignedStateId: stateId }),
+        ...(localGovernmentId && {
+          assignedLocalGovernmentId: localGovernmentId,
+        }),
+        ...(phaseId && { assignedPhaseId: phaseId }),
+        ...(districtId && { assignedDistrictId: districtId }),
       },
       transactionOptions: {
         useTransaction: false,


### PR DESCRIPTION
# Description

- **Assign Location**  
  - Added `assignLocation` endpoint in `AdminController` for assigning a state, local government, phase, and district to a user.  
  - Created `AssignLocationDto` with validation rules for location assignment payloads.  
  - Implemented `assignLocationToUser` in `UserService`, including user existence checks and validation of the referenced state, LGA, phase, and district.  
  - Enhanced AdminController unit tests to cover success and error scenarios for location assignment.

- **Database Schema & Relationships**  
  - Created migration to add `assignedStateId`, `assignedLocalGovernmentId`, `assignedPhaseId`, and `assignedDistrictId` columns to the `users` table.  
  - Defined foreign key constraints linking these new columns to their respective `states`, `local_governments`, `phases`, and `districts` tables.  
  - Updated `User`, `State`, `LocalGovernment`, `Phase`, and `District` entities to include bi-directional relationships for location assignments.

# Type of Change

* [x] feat: New feature 

# How Has This Been Tested?

* [x] Unit tests  
* [x] Integration tests  
* [x] Manual tests:  
  - Ran migration and checked new columns and foreign keys in the database schema.

# Test Evidence
![image](https://github.com/user-attachments/assets/095a5f9c-e811-4250-9dde-52c192c158e9)

# Checklist

* [x] My code follows the project’s coding style  
* [x] My changes generate no new warnings  
* [x] New and existing tests pass locally  