### PR TITLE
feat: update store type

### DIFF
--- a/backend/src/database/migrations/1761330903480-AddStoreTypeDescription.ts
+++ b/backend/src/database/migrations/1761330903480-AddStoreTypeDescription.ts
@@ -1,0 +1,62 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  TableColumn,
+  TableIndex,
+} from 'typeorm';
+
+export class AddStoreTypeDescription1761330903480
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn(
+      'stores',
+      new TableColumn({
+        name: 'store_type_description',
+        type: 'text',
+        isNullable: true,
+      }),
+    );
+
+    await queryRunner.query(`
+            UPDATE stores 
+            SET store_type_description = store_type
+            WHERE store_type IS NOT NULL 
+            AND store_type != '' 
+            AND store_type != 'OTHER'
+        `);
+
+    await queryRunner.query(`
+            UPDATE stores 
+            SET store_type = 'OTHER'
+            WHERE store_type IS NOT NULL
+        `);
+
+    await queryRunner.query(`
+            UPDATE stores 
+            SET store_type = 'OTHER',
+                store_type_description = 'Legacy store type - migrated from previous system'
+            WHERE store_type IS NULL OR store_type = ''
+        `);
+
+    await queryRunner.createIndex(
+      'stores',
+      new TableIndex({
+        columnNames: ['store_type'],
+        name: 'IDX_stores_store_type',
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropIndex('stores', 'IDX_stores_store_type');
+
+    await queryRunner.query(`
+            UPDATE stores 
+            SET store_type = store_type_description
+            WHERE store_type_description IS NOT NULL AND store_type_description != ''
+        `);
+
+    await queryRunner.dropColumn('stores', 'store_type_description');
+  }
+}

--- a/backend/src/modules/admin/admin.service.spec.ts
+++ b/backend/src/modules/admin/admin.service.spec.ts
@@ -36,7 +36,7 @@ describe('AdminService', () => {
     id: '1',
     name: 'Test Store',
     address: '123 Main St',
-    storeType: 'Retail',
+    storeType: 'SHOP' as const,
     latitude: 123.456,
     longitude: 78.901,
     localGovernment: {

--- a/backend/src/modules/store/dto/store.dto.ts
+++ b/backend/src/modules/store/dto/store.dto.ts
@@ -7,6 +7,7 @@ import {
   IsLongitude,
   IsIn,
   ValidateIf,
+  Length,
 } from 'class-validator';
 import { QueryValidator } from '~/helpers/query.helper';
 import { StoreType } from '../types/store.interface';
@@ -47,6 +48,7 @@ export class StoreDto {
 
   @IsString()
   @IsOptional()
+  @Length(1, 500, { message: 'Store type description must be between 1 and 500 characters' })
   @ValidateIf((o) => o.storeType === 'SHOP' || o.storeType === 'OTHER')
   @IsNotEmpty()
   storeTypeDescription?: string;

--- a/backend/src/modules/store/dto/store.dto.ts
+++ b/backend/src/modules/store/dto/store.dto.ts
@@ -5,8 +5,11 @@ import {
   IsOptional,
   IsLatitude,
   IsLongitude,
+  IsIn,
+  ValidateIf,
 } from 'class-validator';
 import { QueryValidator } from '~/helpers/query.helper';
+import { StoreType } from '../types/store.interface';
 
 export class StoreDto {
   @IsString()
@@ -27,7 +30,26 @@ export class StoreDto {
 
   @IsString()
   @IsNotEmpty()
-  storeType: string;
+  @IsIn([
+    'SHOP',
+    'REFUSE_SITE',
+    'SCHOOL',
+    'HOSPITAL',
+    'BAR_RESTAURANT',
+    'FUELING_STATION',
+    'HOTEL',
+    'RECREATION_PARK',
+    'FINANCIAL_INSTITUTION',
+    'RELIGIOUS',
+    'OTHER',
+  ])
+  storeType: StoreType;
+
+  @IsString()
+  @IsOptional()
+  @ValidateIf((o) => o.storeType === 'SHOP' || o.storeType === 'OTHER')
+  @IsNotEmpty()
+  storeTypeDescription?: string;
 
   @IsString()
   @IsOptional()
@@ -81,6 +103,23 @@ export class StoreQueryValidator extends QueryValidator {
   @IsString()
   @IsOptional()
   districtId?: string;
+
+  @IsString()
+  @IsOptional()
+  @IsIn([
+    'SHOP',
+    'REFUSE_SITE',
+    'SCHOOL',
+    'HOSPITAL',
+    'BAR_RESTAURANT',
+    'FUELING_STATION',
+    'HOTEL',
+    'RECREATION_PARK',
+    'FINANCIAL_INSTITUTION',
+    'RELIGIOUS',
+    'OTHER',
+  ])
+  storeType?: StoreType;
 
   @IsOptional()
   @IsLatitude()

--- a/backend/src/modules/store/entities/store.entity.ts
+++ b/backend/src/modules/store/entities/store.entity.ts
@@ -1,3 +1,4 @@
+import { StoreType } from '../types/store.interface';
 import { User } from '~/modules/user/entities/user.entity';
 import { State } from '~/modules/state/entities/state.entity';
 import { Phase } from '~/modules/phase/entities/phase.entity';
@@ -31,7 +32,10 @@ export class Store extends AbstractBaseEntity {
   address: string;
 
   @Column()
-  storeType: string;
+  storeType: StoreType;
+
+  @Column({ type: 'text', nullable: true })
+  storeTypeDescription?: string;
 
   @Column({ type: 'text', nullable: true })
   landmarks?: string;

--- a/backend/src/modules/store/store.controller.spec.ts
+++ b/backend/src/modules/store/store.controller.spec.ts
@@ -14,7 +14,8 @@ describe('StoreController', () => {
     id: '1',
     name: 'Test Store',
     address: '123 Main St',
-    storeType: 'Retail',
+    storeType: 'SHOP' as const,
+    storeTypeDescription: 'Electronics store',
     latitude: 123.456,
     longitude: 78.901,
     localGovernmentId: '1',
@@ -58,7 +59,8 @@ describe('StoreController', () => {
       const storeDto: Omit<StoreDto, 'enumeratorId'> = {
         name: 'Test Store',
         address: '123 Main St',
-        storeType: 'Retail',
+        storeType: 'SHOP',
+        storeTypeDescription: 'Electronics store',
         latitude: 123.456,
         longitude: 78.901,
         localGovernmentId: '1',
@@ -85,7 +87,7 @@ describe('StoreController', () => {
       const storeDto: Omit<StoreDto, 'enumeratorId'> = {
         name: 'Test Store',
         address: '123 Main St',
-        storeType: 'Retail',
+        storeType: 'HOSPITAL',
         latitude: 123.456,
         longitude: 78.901,
         localGovernmentId: '1',

--- a/backend/src/modules/store/store.service.spec.ts
+++ b/backend/src/modules/store/store.service.spec.ts
@@ -45,7 +45,8 @@ describe('StoreService', () => {
     id: '1',
     name: 'Test Store',
     address: '123 Main St',
-    storeType: 'Retail',
+    storeType: 'SHOP' as const,
+    storeTypeDescription: 'Electronics store',
     latitude: 123.456,
     longitude: 78.901,
     localGovernment: {
@@ -146,7 +147,8 @@ describe('StoreService', () => {
       const storeDto: Omit<StoreDto, 'enumeratorId'> = {
         name: 'Test Store',
         address: '123 Main St',
-        storeType: 'Retail',
+        storeType: 'SHOP',
+        storeTypeDescription: 'Electronics store',
         latitude: 123.456,
         longitude: 78.901,
         localGovernmentId: '1',
@@ -172,7 +174,7 @@ describe('StoreService', () => {
       const storeDto: Omit<StoreDto, 'enumeratorId'> = {
         name: 'Test Store',
         address: '123 Main St',
-        storeType: 'Retail',
+        storeType: 'HOSPITAL',
         latitude: 123.456,
         longitude: 78.901,
         localGovernmentId: '1',
@@ -192,6 +194,184 @@ describe('StoreService', () => {
       ).rejects.toMatchObject({
         status: HttpStatus.INTERNAL_SERVER_ERROR,
         message: SYS_MSG.RESOURCE_CREATION_FAILED('Store'),
+      });
+    });
+
+    it('should throw error when SHOP store type is provided without description', async () => {
+      const storeDto: Omit<StoreDto, 'enumeratorId'> = {
+        name: 'Test Store',
+        address: '123 Main St',
+        storeType: 'SHOP',
+        latitude: 123.456,
+        longitude: 78.901,
+        localGovernmentId: '1',
+        stateId: '1',
+      };
+      const enumeratorId = '1';
+
+      await expect(service.createStore(enumeratorId, storeDto)).rejects.toThrow(
+        CustomHttpException,
+      );
+      await expect(
+        service.createStore(enumeratorId, storeDto),
+      ).rejects.toMatchObject({
+        status: HttpStatus.BAD_REQUEST,
+        message:
+          'Store type description is required when store type is SHOP or OTHER',
+      });
+    });
+
+    it('should throw error when OTHER store type is provided without description', async () => {
+      const storeDto: Omit<StoreDto, 'enumeratorId'> = {
+        name: 'Test Store',
+        address: '123 Main St',
+        storeType: 'OTHER',
+        latitude: 123.456,
+        longitude: 78.901,
+        localGovernmentId: '1',
+        stateId: '1',
+      };
+      const enumeratorId = '1';
+
+      await expect(service.createStore(enumeratorId, storeDto)).rejects.toThrow(
+        CustomHttpException,
+      );
+      await expect(
+        service.createStore(enumeratorId, storeDto),
+      ).rejects.toMatchObject({
+        status: HttpStatus.BAD_REQUEST,
+        message:
+          'Store type description is required when store type is SHOP or OTHER',
+      });
+    });
+
+    it('should throw error when SHOP store type has empty string description', async () => {
+      const storeDto: Omit<StoreDto, 'enumeratorId'> = {
+        name: 'Test Store',
+        address: '123 Main St',
+        storeType: 'SHOP',
+        storeTypeDescription: '   ', // whitespace only
+        latitude: 123.456,
+        longitude: 78.901,
+        localGovernmentId: '1',
+        stateId: '1',
+      };
+      const enumeratorId = '1';
+
+      await expect(service.createStore(enumeratorId, storeDto)).rejects.toThrow(
+        CustomHttpException,
+      );
+      await expect(
+        service.createStore(enumeratorId, storeDto),
+      ).rejects.toMatchObject({
+        status: HttpStatus.BAD_REQUEST,
+        message:
+          'Store type description is required when store type is SHOP or OTHER',
+      });
+    });
+
+    it('should throw error when OTHER store type has empty string description', async () => {
+      const storeDto: Omit<StoreDto, 'enumeratorId'> = {
+        name: 'Test Store',
+        address: '123 Main St',
+        storeType: 'OTHER',
+        storeTypeDescription: '', // empty string
+        latitude: 123.456,
+        longitude: 78.901,
+        localGovernmentId: '1',
+        stateId: '1',
+      };
+      const enumeratorId = '1';
+
+      await expect(service.createStore(enumeratorId, storeDto)).rejects.toThrow(
+        CustomHttpException,
+      );
+      await expect(
+        service.createStore(enumeratorId, storeDto),
+      ).rejects.toMatchObject({
+        status: HttpStatus.BAD_REQUEST,
+        message:
+          'Store type description is required when store type is SHOP or OTHER',
+      });
+    });
+
+    it('should create store successfully when SHOP store type has description', async () => {
+      const storeDto: Omit<StoreDto, 'enumeratorId'> = {
+        name: 'Test Store',
+        address: '123 Main St',
+        storeType: 'SHOP',
+        storeTypeDescription: 'Electronics store',
+        latitude: 123.456,
+        longitude: 78.901,
+        localGovernmentId: '1',
+        stateId: '1',
+      };
+      const enumeratorId = '1';
+
+      jest.spyOn(storeModelAction, 'create').mockResolvedValue(mockStore);
+
+      const result = await service.createStore(enumeratorId, storeDto);
+
+      expect(storeModelAction.create).toHaveBeenCalledWith({
+        createPayload: { ...storeDto, enumeratorId },
+        transactionOptions: { useTransaction: false },
+      });
+      expect(result).toEqual({
+        data: mockStore,
+        message: SYS_MSG.RESOURCE_CREATED_SUCCESSFULLY('Store'),
+      });
+    });
+
+    it('should create store successfully when OTHER store type has description', async () => {
+      const storeDto: Omit<StoreDto, 'enumeratorId'> = {
+        name: 'Test Store',
+        address: '123 Main St',
+        storeType: 'OTHER',
+        storeTypeDescription: 'Custom business type',
+        latitude: 123.456,
+        longitude: 78.901,
+        localGovernmentId: '1',
+        stateId: '1',
+      };
+      const enumeratorId = '1';
+
+      jest.spyOn(storeModelAction, 'create').mockResolvedValue(mockStore);
+
+      const result = await service.createStore(enumeratorId, storeDto);
+
+      expect(storeModelAction.create).toHaveBeenCalledWith({
+        createPayload: { ...storeDto, enumeratorId },
+        transactionOptions: { useTransaction: false },
+      });
+      expect(result).toEqual({
+        data: mockStore,
+        message: SYS_MSG.RESOURCE_CREATED_SUCCESSFULLY('Store'),
+      });
+    });
+
+    it('should create store successfully when non-SHOP/OTHER store type is provided without description', async () => {
+      const storeDto: Omit<StoreDto, 'enumeratorId'> = {
+        name: 'Test Store',
+        address: '123 Main St',
+        storeType: 'HOSPITAL',
+        latitude: 123.456,
+        longitude: 78.901,
+        localGovernmentId: '1',
+        stateId: '1',
+      };
+      const enumeratorId = '1';
+
+      jest.spyOn(storeModelAction, 'create').mockResolvedValue(mockStore);
+
+      const result = await service.createStore(enumeratorId, storeDto);
+
+      expect(storeModelAction.create).toHaveBeenCalledWith({
+        createPayload: { ...storeDto, enumeratorId },
+        transactionOptions: { useTransaction: false },
+      });
+      expect(result).toEqual({
+        data: mockStore,
+        message: SYS_MSG.RESOURCE_CREATED_SUCCESSFULLY('Store'),
       });
     });
   });
@@ -347,7 +527,7 @@ describe('StoreService', () => {
       const storeDto: Partial<StoreDto> = {
         name: 'Updated Store',
         address: '456 New St',
-        storeType: 'Retail',
+        storeType: 'HOSPITAL',
         latitude: 123.456,
         longitude: 78.901,
         localGovernmentId: '1',
@@ -378,7 +558,7 @@ describe('StoreService', () => {
       const storeDto: Partial<StoreDto> = {
         name: 'Updated Store',
         address: '456 New St',
-        storeType: 'Retail',
+        storeType: 'HOSPITAL',
         latitude: 123.456,
         longitude: 78.901,
         localGovernmentId: '1',
@@ -397,6 +577,121 @@ describe('StoreService', () => {
       ).rejects.toMatchObject({
         status: HttpStatus.INTERNAL_SERVER_ERROR,
         message: SYS_MSG.RESOURCE_UPDATE_FAILED('Store'),
+      });
+    });
+
+    it('should throw error when updating to SHOP store type without description', async () => {
+      const storeId = '1';
+      const userId = '1';
+      const storeDto: Partial<StoreDto> = {
+        storeType: 'SHOP',
+      };
+
+      await expect(
+        service.updateStore(storeId, userId, storeDto),
+      ).rejects.toThrow(CustomHttpException);
+      await expect(
+        service.updateStore(storeId, userId, storeDto),
+      ).rejects.toMatchObject({
+        status: HttpStatus.BAD_REQUEST,
+        message:
+          'Store type description is required when store type is SHOP or OTHER',
+      });
+    });
+
+    it('should throw error when updating to OTHER store type without description', async () => {
+      const storeId = '1';
+      const userId = '1';
+      const storeDto: Partial<StoreDto> = {
+        storeType: 'OTHER',
+      };
+
+      await expect(
+        service.updateStore(storeId, userId, storeDto),
+      ).rejects.toThrow(CustomHttpException);
+      await expect(
+        service.updateStore(storeId, userId, storeDto),
+      ).rejects.toMatchObject({
+        status: HttpStatus.BAD_REQUEST,
+        message:
+          'Store type description is required when store type is SHOP or OTHER',
+      });
+    });
+
+    it('should update store successfully when SHOP store type has description', async () => {
+      const storeId = '1';
+      const userId = '1';
+      const storeDto: Partial<StoreDto> = {
+        storeType: 'SHOP',
+        storeTypeDescription: 'Electronics store',
+      };
+
+      jest.spyOn(storeModelAction, 'update').mockResolvedValue({
+        ...mockStore,
+        ...storeDto,
+      });
+
+      const result = await service.updateStore(storeId, userId, storeDto);
+
+      expect(storeModelAction.update).toHaveBeenCalledWith({
+        identifierOptions: { id: storeId, enumeratorId: userId },
+        updatePayload: storeDto,
+        transactionOptions: { useTransaction: false },
+      });
+      expect(result).toEqual({
+        data: { ...mockStore, ...storeDto },
+        message: SYS_MSG.RESOURCE_UPDATED_SUCCESSFULLY('Store'),
+      });
+    });
+
+    it('should update store successfully when OTHER store type has description', async () => {
+      const storeId = '1';
+      const userId = '1';
+      const storeDto: Partial<StoreDto> = {
+        storeType: 'OTHER',
+        storeTypeDescription: 'Custom business type',
+      };
+
+      jest.spyOn(storeModelAction, 'update').mockResolvedValue({
+        ...mockStore,
+        ...storeDto,
+      });
+
+      const result = await service.updateStore(storeId, userId, storeDto);
+
+      expect(storeModelAction.update).toHaveBeenCalledWith({
+        identifierOptions: { id: storeId, enumeratorId: userId },
+        updatePayload: storeDto,
+        transactionOptions: { useTransaction: false },
+      });
+      expect(result).toEqual({
+        data: { ...mockStore, ...storeDto },
+        message: SYS_MSG.RESOURCE_UPDATED_SUCCESSFULLY('Store'),
+      });
+    });
+
+    it('should update store successfully when non-SHOP/OTHER store type is provided without description', async () => {
+      const storeId = '1';
+      const userId = '1';
+      const storeDto: Partial<StoreDto> = {
+        storeType: 'HOSPITAL',
+      };
+
+      jest.spyOn(storeModelAction, 'update').mockResolvedValue({
+        ...mockStore,
+        ...storeDto,
+      });
+
+      const result = await service.updateStore(storeId, userId, storeDto);
+
+      expect(storeModelAction.update).toHaveBeenCalledWith({
+        identifierOptions: { id: storeId, enumeratorId: userId },
+        updatePayload: storeDto,
+        transactionOptions: { useTransaction: false },
+      });
+      expect(result).toEqual({
+        data: { ...mockStore, ...storeDto },
+        message: SYS_MSG.RESOURCE_UPDATED_SUCCESSFULLY('Store'),
       });
     });
   });

--- a/backend/src/modules/store/store.service.ts
+++ b/backend/src/modules/store/store.service.ts
@@ -27,6 +27,17 @@ export class StoreService {
     enumeratorId: string,
     storeDto: Omit<StoreDto, 'enumeratorId'>,
   ): Promise<AbstractResponseDto<StoreInterface>> {
+    if (
+      (storeDto.storeType === 'SHOP' || storeDto.storeType === 'OTHER') &&
+      (!storeDto.storeTypeDescription ||
+        storeDto.storeTypeDescription.trim() === '')
+    ) {
+      throw new CustomHttpException(
+        'Store type description is required when store type is SHOP or OTHER',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
     const createStorePayload: CreateStoreRecordOptions = {
       createPayload: { ...storeDto, enumeratorId },
       transactionOptions: { useTransaction: false },
@@ -144,6 +155,18 @@ export class StoreService {
     userId: string,
     storeDto: Partial<StoreDto>,
   ): Promise<AbstractResponseDto<StoreInterface>> {
+    if (
+      storeDto.storeType &&
+      (storeDto.storeType === 'SHOP' || storeDto.storeType === 'OTHER') &&
+      (!storeDto.storeTypeDescription ||
+        storeDto.storeTypeDescription.trim() === '')
+    ) {
+      throw new CustomHttpException(
+        'Store type description is required when store type is SHOP or OTHER',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
     const updateStorePayload: UpdateStoreRecordOptions = {
       identifierOptions: { id, enumeratorId: userId },
       updatePayload: storeDto,

--- a/backend/src/modules/store/types/list-store.type.ts
+++ b/backend/src/modules/store/types/list-store.type.ts
@@ -1,3 +1,4 @@
+import { StoreType } from './store.interface';
 import ListGenericRecord from '~/types/generic/list-record.type';
 import { FilterOptions, PaginationOptions } from '~/helpers/query.helper';
 
@@ -8,6 +9,7 @@ interface StoreFilterOptions extends FilterOptions {
   localGovernmentId?: string;
   phaseId?: string;
   districtId?: string;
+  storeType?: StoreType;
   minLat?: `${number}`;
   maxLat?: `${number}`;
   minLng?: `${number}`;

--- a/backend/src/modules/store/types/store.interface.ts
+++ b/backend/src/modules/store/types/store.interface.ts
@@ -1,11 +1,25 @@
 import { AbstractBaseInterface } from '~/database/base/base.interface';
 
+export type StoreType =
+  | 'SHOP'
+  | 'REFUSE_SITE'
+  | 'SCHOOL'
+  | 'HOSPITAL'
+  | 'BAR_RESTAURANT'
+  | 'FUELING_STATION'
+  | 'HOTEL'
+  | 'RECREATION_PARK'
+  | 'FINANCIAL_INSTITUTION'
+  | 'RELIGIOUS'
+  | 'OTHER';
+
 export interface StoreInterface extends AbstractBaseInterface {
   name: string;
   localGovernmentId?: string;
   stateId?: string;
   address: string;
-  storeType: string;
+  storeType: StoreType;
+  storeTypeDescription?: string;
   landmarks?: string;
   photos?: string[];
   latitude: number;


### PR DESCRIPTION
# Description

This PR introduces a new field and validation logic for store creation and updates:

- Added a migration to include a `store_type_description` column in the `stores` table.
- Updated the `StoreDto` to validate `storeTypeDescription` when the store type is `SHOP` or `OTHER`.
- Enhanced the `StoreService` to ensure a description is required for these store types during both creation and update operations.
- Modified relevant tests to cover the new validation rules and confirm correct handling of store types and descriptions.

# Type of Change

* [x] feat: New feature
* [x] test: Test additions/updates

# How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests

# Test Evidence
<img width="273" height="94" alt="image" src="https://github.com/user-attachments/assets/b3a130f5-ac5c-43b1-8b00-06f4344457eb" />

# Checklist

* [x] My code follows the project's coding style
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published
* [x] I have included a screenshot showing all tests passing

# Additional Notes

This change ensures data consistency and enforces more descriptive store information, improving validation integrity across store-related operations.